### PR TITLE
refactor lc's libpressio module to use a common header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,17 +45,18 @@ else()
 endif()
 
 file(GLOB LC_SOURCES CONFIGURE_DEPENDS components/*.h verifiers/*.h preprocessors/*.h)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cpu)
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lc.cpp
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_Host_LC-Framework.py --output_dir ${CMAKE_CURRENT_BINARY_DIR} ${VERBOSE_FLAG}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cpu/lc.cpp ${CMAKE_CURRENT_BINARY_DIR}/cpu/include/consts.h
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_Host_LC-Framework.py --output_dir ${CMAKE_CURRENT_BINARY_DIR}/cpu ${VERBOSE_FLAG}
     DEPENDS ${LC_SOURCES} generate_Host_LC-Framework.py framework.cu
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-add_executable(lc ${CMAKE_CURRENT_BINARY_DIR}/lc.cpp)
+add_executable(lc ${CMAKE_CURRENT_BINARY_DIR}/cpu/lc.cpp)
 target_include_directories(lc PRIVATE 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/components>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cpu/components>
     )
 target_compile_definitions(lc PRIVATE USE_CPU)
 target_link_libraries(lc PRIVATE OpenMP::OpenMP_CXX)
@@ -63,18 +64,39 @@ install(TARGETS lc EXPORT LCTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
+option(LC_BUILD_CUDA "enable support for cuda GPUs" OFF)
+if(LC_BUILD_CUDA)
+enable_language(CUDA)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gpu)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gpu/lc.cu ${CMAKE_CURRENT_BINARY_DIR}/gpu/include/consts.h
+        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_Device_LC-Framework.py --output_dir ${CMAKE_CURRENT_BINARY_DIR}/gpu ${VERBOSE_FLAG}
+        DEPENDS ${LC_SOURCES} generate_Device_LC-Framework.py framework.cu
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+    add_executable(lc-gpu ${CMAKE_CURRENT_BINARY_DIR}/gpu/lc.cu)
+    target_include_directories(lc-gpu PRIVATE 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/gpu/components>
+        )
+    target_compile_definitions(lc-gpu PRIVATE USE_GPU)
+    target_link_libraries(lc-gpu PRIVATE OpenMP::OpenMP_CXX)
+    install(TARGETS lc-gpu EXPORT LCTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+endif()
+
+
 
 option(LC_BUILD_LIBPRESSIO_PLUGIN "build support for calling LC from LibPressio" OFF)
 if(LC_BUILD_LIBPRESSIO_PLUGIN)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libpressio/)
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libpressio/lc.cpp
-        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_Host_LC-Framework.py --base_file ${CMAKE_CURRENT_SOURCE_DIR}/lc-libpressio-plugin.cpp --output_dir ${CMAKE_CURRENT_BINARY_DIR}/libpressio/ ${VERBOSE_FLAG}
-        DEPENDS ${LC_SOURCES} generate_Host_LC-Framework.py ./lc-libpressio-plugin.cpp
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        )
     find_package(LibPressio REQUIRED)
-    add_library(libpressio_lc ${CMAKE_CURRENT_BINARY_DIR}/libpressio/lc.cpp)
+    add_library(libpressio_lc 
+        lc-libpressio-plugin.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/cpu/include/consts.h
+        )
+
     target_link_libraries(libpressio_lc PRIVATE LibPressio::libpressio OpenMP::OpenMP_CXX)
     target_compile_definitions(libpressio_lc PRIVATE USE_CPU)
     target_include_directories(libpressio_lc PUBLIC 
@@ -82,7 +104,7 @@ if(LC_BUILD_LIBPRESSIO_PLUGIN)
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
         )
     target_include_directories(libpressio_lc PRIVATE 
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libpressio/components>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cpu/>
         )
     install(TARGETS libpressio_lc EXPORT LCTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/framework-common.h
+++ b/framework-common.h
@@ -1,0 +1,19 @@
+#ifndef LC_FRAMEWORK_COMMON_H
+#define LC_FRAMEWORK_COMMON_H
+#include <vector>
+#include <string>
+#include <map>
+#include <cstdint>
+
+using byte = unsigned char;
+inline constexpr unsigned int max_stages = 8;
+void verify(const int size, const std::byte* const recon, const std::byte* const orig, std::vector<std::pair<std::byte, std::vector<double>>> verifs);
+std::map<std::string, byte> getVerifMap();
+std::map<std::string, byte> getPreproMap();
+std::map<std::string, byte> getCompMap();
+std::string getPipeline(unsigned long long pipeline, const int stages);
+void h_encode(const unsigned long long chain, const byte* const __restrict__ input, const int insize, byte* const __restrict__ output, int& outsize, uint32_t nthreads);
+void h_decode(const unsigned long long chain, const byte* const __restrict__ input, byte* const __restrict__ output, int& outsize, uint32_t n_threads);
+void h_preprocess_encode(int& hpreencsize, byte*& hpreencdata, std::vector<std::pair<byte, std::vector<double>>> prepros);
+void h_preprocess_decode(int& hpredecsize, byte*& hpredecdata, std::vector<std::pair<byte, std::vector<double>>> prepros);
+#endif /* end of include guard: LC_FRAMEWORK_COMMON_H */

--- a/generate_Device_LC-Framework.py
+++ b/generate_Device_LC-Framework.py
@@ -142,7 +142,7 @@ file = args.output_dir + "/lc.cu"
 # update switch device encode
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-device-encode-beg##[\s\S]*##switch-device-encode-end##", contents)
+  m = re.search(r"##switch-device-encode-beg##[\s\S]*##switch-device-encode-end##", contents)
   str_to_add = ''
   for c in gpucomps:
     c = c[2:]
@@ -155,7 +155,7 @@ with open(file, "r+") as f:
 # update switch device decode
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-device-decode-beg##[\s\S]*##switch-device-decode-end##", contents)
+  m = re.search(r"##switch-device-decode-beg##[\s\S]*##switch-device-decode-end##", contents)
   str_to_add = ''
   for c in gpucomps:
     c = c[2:]
@@ -168,7 +168,7 @@ with open(file, "r+") as f:
 # update switch pipeline
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-pipeline-beg##[\s\S]*##switch-pipeline-end##", contents)
+  m = re.search(r"##switch-pipeline-beg##[\s\S]*##switch-pipeline-end##", contents)
   str_to_add = ''
   for c in gpucomps:
     c = c[2:]
@@ -181,7 +181,7 @@ with open(file, "r+") as f:
 #update switch verify
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-verify-beg##[\s\S]*##switch-verify-end##", contents)
+  m = re.search(r"##switch-verify-beg##[\s\S]*##switch-verify-end##", contents)
   str_to_add = ''
   for c in gpuverifier:
     c = c[2:]
@@ -195,7 +195,7 @@ with open(file, "r+") as f:
 #update switch device preprocess encode
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-device-preprocess-encode-beg##[\s\S]*##switch-device-preprocess-encode-end##", contents)
+  m = re.search(r"##switch-device-preprocess-encode-beg##[\s\S]*##switch-device-preprocess-encode-end##", contents)
   str_to_add = ''
   for c in gpupreprocess:
     c = c[2:]
@@ -208,7 +208,7 @@ with open(file, "r+") as f:
 #update switch device preprocess decode
 with open(file, "r+") as f:
   contents = f.read()
-  m = re.search("##switch-device-preprocess-decode-beg##[\s\S]*##switch-device-preprocess-decode-end##", contents)
+  m = re.search(r"##switch-device-preprocess-decode-beg##[\s\S]*##switch-device-preprocess-decode-end##", contents)
   str_to_add = ''
   for c in gpupreprocess:
     c = c[2:]
@@ -221,7 +221,7 @@ with open(file, "r+") as f:
 # update enum map
 with open(file, "r+") as f:
     contents = f.read()
-    m = re.search("##component-map-beg##[\s\S]*##component-map-end##", contents)
+    m = re.search(r"##component-map-beg##[\s\S]*##component-map-end##", contents)
     str_to_add = ''
     i = 0
     for c in gpucomps:
@@ -236,7 +236,7 @@ with open(file, "r+") as f:
 # update preprocessor map
 with open(file, "r+") as f:
     contents = f.read()
-    m = re.search("##preprocessor-map-beg##[\s\S]*##preprocessor-map-end##", contents)
+    m = re.search(r"##preprocessor-map-beg##[\s\S]*##preprocessor-map-end##", contents)
     str_to_add = ''
     for c in gpupreprocess:
         c = c[2:]
@@ -249,7 +249,7 @@ with open(file, "r+") as f:
 # update verifier map
 with open(file, "r+") as f:
     contents = f.read()
-    m = re.search("##verifier-map-beg##[\s\S]*##verifier-map-end##", contents)
+    m = re.search(r"##verifier-map-beg##[\s\S]*##verifier-map-end##", contents)
     str_to_add = ''
     for c in gpuverifier:
         c = c[2:]

--- a/preprocessors/d_QUANT_ABS_0_f32.h
+++ b/preprocessors/d_QUANT_ABS_0_f32.h
@@ -79,13 +79,13 @@ static __global__ void d_iQUANT_ABS_0_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_ABS_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: threshold must be larger than error_bound\n");}
 
   const float eb2 = 2 * errorbound;
   const float inv_eb2 = 0.5f / errorbound;
@@ -96,11 +96,11 @@ static inline void d_QUANT_ABS_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_ABS_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   const float eb2 = 2 * errorbound;
 

--- a/preprocessors/d_QUANT_ABS_0_f64.h
+++ b/preprocessors/d_QUANT_ABS_0_f64.h
@@ -79,13 +79,13 @@ static __global__ void d_iQUANT_ABS_0_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_ABS_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: threshold must be larger than error_bound\n");}
 
   const double eb2 = 2 * errorbound;
   const double inv_eb2 = 0.5 / errorbound;
@@ -96,11 +96,11 @@ static inline void d_QUANT_ABS_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_ABS_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
 
   const double eb2 = 2 * errorbound;
 

--- a/preprocessors/d_QUANT_ABS_R_f32.h
+++ b/preprocessors/d_QUANT_ABS_R_f32.h
@@ -96,13 +96,13 @@ static __global__ void d_iQUANT_ABS_R_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_ABS_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: threshold must be larger than error_bound\n");}
 
   const float inv_eb = 1 / errorbound;
 
@@ -112,11 +112,11 @@ static inline void d_QUANT_ABS_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_ABS_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   d_iQUANT_ABS_R_f32_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len, data, errorbound);
 }

--- a/preprocessors/d_QUANT_ABS_R_f64.h
+++ b/preprocessors/d_QUANT_ABS_R_f64.h
@@ -100,13 +100,13 @@ static __global__ void d_iQUANT_ABS_R_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_ABS_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: threshold must be larger than error_bound\n");}
 
   const double inv_eb = 1 / errorbound;
 
@@ -116,11 +116,11 @@ static inline void d_QUANT_ABS_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_ABS_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
 
   d_iQUANT_ABS_R_f64_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len, data, errorbound);
 }

--- a/preprocessors/d_QUANT_R2R_0_f32.h
+++ b/preprocessors/d_QUANT_R2R_0_f32.h
@@ -45,7 +45,9 @@ Sponsor: This code is based upon work supported by the U.S. Department of Energy
 static __global__ void d_QUANT_R2R_0_f32_kernel(const int len, byte* const __restrict__ data, byte* const __restrict__ orig_data, const float errorbound, const float* maxf, const float* minf, const float threshold)
 {
   float* const orig_data_f = (float*)orig_data;
+#ifdef DEBUG
   int* const orig_data_i = (int*)orig_data;
+#endif
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;
 
@@ -97,13 +99,13 @@ static __global__ void d_iQUANT_R2R_0_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_R2R_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: threshold must be larger than error_bound\n");}
 
   byte* d_new_data;
   if (cudaSuccess != cudaMalloc((void**) &d_new_data, size + sizeof(float))) {
@@ -124,9 +126,9 @@ static inline void d_QUANT_R2R_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_R2R_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n");}
 
   d_iQUANT_R2R_0_f32_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len - 1, data);
 

--- a/preprocessors/d_QUANT_R2R_0_f64.h
+++ b/preprocessors/d_QUANT_R2R_0_f64.h
@@ -95,13 +95,13 @@ static __global__ void d_iQUANT_R2R_0_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_R2R_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: threshold must be larger than error_bound\n");}
 
   byte* d_new_data;
   if (cudaSuccess != cudaMalloc((void**) &d_new_data, size + sizeof(double))) {
@@ -122,9 +122,9 @@ static inline void d_QUANT_R2R_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_R2R_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n");}
 
   d_iQUANT_R2R_0_f64_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len - 1, data);
 

--- a/preprocessors/d_QUANT_R2R_R_f32.h
+++ b/preprocessors/d_QUANT_R2R_R_f32.h
@@ -111,13 +111,13 @@ static __global__ void d_iQUANT_R2R_R_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_R2R_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: threshold must be larger than error_bound\n");}
 
   byte* d_new_data;
   if (cudaSuccess != cudaMalloc((void**) &d_new_data, size + sizeof(float))) {
@@ -138,9 +138,9 @@ static inline void d_QUANT_R2R_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_R2R_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n");}
 
   d_iQUANT_R2R_R_f32_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len - 1, data);
 

--- a/preprocessors/d_QUANT_R2R_R_f64.h
+++ b/preprocessors/d_QUANT_R2R_R_f64.h
@@ -115,13 +115,13 @@ static __global__ void d_iQUANT_R2R_R_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_R2R_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: threshold must be larger than error_bound\n");}
 
   byte* d_new_data;
   if (cudaSuccess != cudaMalloc((void**) &d_new_data, size + sizeof(double))) {
@@ -142,9 +142,9 @@ static inline void d_QUANT_R2R_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_R2R_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n");}
 
   d_iQUANT_R2R_R_f64_kernel<<<(len + TPB - 1) / TPB, TPB>>>(len - 1, data);
 

--- a/preprocessors/d_QUANT_REL_0_f32.h
+++ b/preprocessors/d_QUANT_REL_0_f32.h
@@ -135,13 +135,13 @@ static __global__ void d_iQUANT_REL_0_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_REL_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < 1E-5) {fprintf(stderr, "QUANT_REL_0_f32: ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_0_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-5) {throw std::runtime_error("QUANT_REL_0_f32: ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_0_f32: ERROR: threshold must be larger than error_bound\n");}
 
   const float log2eb = 2 * d_QUANT_REL_0_f32_log2approxf(1 + errorbound);
   const float inv_log2eb = 1 / log2eb;
@@ -152,11 +152,11 @@ static inline void d_QUANT_REL_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_REL_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_0_f32: ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // minimum positive normalized value
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_0_f32: ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // minimum positive normalized value
 
   const float log2eb = 2 * d_QUANT_REL_0_f32_log2approxf(1 + errorbound);
 

--- a/preprocessors/d_QUANT_REL_0_f64.h
+++ b/preprocessors/d_QUANT_REL_0_f64.h
@@ -133,13 +133,13 @@ static __global__ void d_iQUANT_REL_0_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_REL_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_0_f64: ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_0_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_0_f64: ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_0_f64: ERROR: threshold must be larger than error_bound\n");}
 
   const double log2eb = 2 * d_QUANT_REL_0_f64_log2approx(1 + errorbound);
   const double inv_log2eb = 1 / log2eb;
@@ -150,11 +150,11 @@ static inline void d_QUANT_REL_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_REL_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_0_f64: ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // minimum positive normalized value
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_0_f64: ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // minimum positive normalized value
 
   const double log2eb = 2 * d_QUANT_REL_0_f64_log2approx(1 + errorbound);
 

--- a/preprocessors/d_QUANT_REL_R_f32.h
+++ b/preprocessors/d_QUANT_REL_R_f32.h
@@ -150,13 +150,13 @@ static __global__ void d_iQUANT_REL_R_f32_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_REL_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_R_f32: ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_R_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_R_f32: ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_R_f32: ERROR: threshold must be larger than error_bound\n");}
 
   const float log2eb = d_QUANT_REL_R_f32_log2approxf(1 + errorbound);
   const float inv_log2eb = 1 / log2eb;
@@ -167,11 +167,11 @@ static inline void d_QUANT_REL_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_REL_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_R_f32: ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // minimum positive normalized value
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_R_f32: ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // minimum positive normalized value
 
   const float log2eb = d_QUANT_REL_R_f32_log2approxf(1 + errorbound);
 

--- a/preprocessors/d_QUANT_REL_R_f64.h
+++ b/preprocessors/d_QUANT_REL_R_f64.h
@@ -154,13 +154,13 @@ static __global__ void d_iQUANT_REL_R_f64_kernel(const int len, byte* const __re
 
 static inline void d_QUANT_REL_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_R_f64: ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_R_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_R_f64: ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_R_f64: ERROR: threshold must be larger than error_bound\n");}
 
   const double log2eb = d_QUANT_REL_R_f64_log2approx(1 + errorbound);
   const double inv_log2eb = 1 / log2eb;
@@ -171,11 +171,11 @@ static inline void d_QUANT_REL_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void d_iQUANT_REL_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_R_f64: ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // minimum positive normalized value
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_R_f64: ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // minimum positive normalized value
 
   const double log2eb = d_QUANT_REL_R_f64_log2approx(1 + errorbound);
 

--- a/preprocessors/h_QUANT_ABS_0_f32.h
+++ b/preprocessors/h_QUANT_ABS_0_f32.h
@@ -39,13 +39,13 @@ Sponsor: This code is based upon work supported by the U.S. Department of Energy
 
 static inline void h_QUANT_ABS_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: threshold must be larger than error_bound\n");}
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;
@@ -77,11 +77,11 @@ static inline void h_QUANT_ABS_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_ABS_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;

--- a/preprocessors/h_QUANT_ABS_0_f64.h
+++ b/preprocessors/h_QUANT_ABS_0_f64.h
@@ -39,13 +39,13 @@ Sponsor: This code is based upon work supported by the U.S. Department of Energy
 
 static inline void h_QUANT_ABS_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: threshold must be larger than error_bound\n");}
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;
@@ -77,11 +77,11 @@ static inline void h_QUANT_ABS_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_ABS_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;

--- a/preprocessors/h_QUANT_ABS_R_f32.h
+++ b/preprocessors/h_QUANT_ABS_R_f32.h
@@ -48,13 +48,13 @@ static unsigned int h_QUANT_ABS_R_f32_hash(unsigned int val)
 
 static inline void h_QUANT_ABS_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: threshold must be larger than error_bound\n");}
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;
@@ -88,11 +88,11 @@ static inline void h_QUANT_ABS_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_ABS_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_ABS_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_ABS_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;

--- a/preprocessors/h_QUANT_ABS_R_f64.h
+++ b/preprocessors/h_QUANT_ABS_R_f64.h
@@ -48,13 +48,13 @@ static unsigned int h_QUANT_ABS_R_f64_hash(unsigned int val)
 
 static inline void h_QUANT_ABS_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: threshold must be larger than error_bound\n");}
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;
@@ -90,11 +90,11 @@ static inline void h_QUANT_ABS_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_ABS_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_ABS_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_ABS_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_ABS_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;

--- a/preprocessors/h_QUANT_R2R_0_f32.h
+++ b/preprocessors/h_QUANT_R2R_0_f32.h
@@ -39,9 +39,9 @@ Sponsor: This code is based upon work supported by the U.S. Department of Energy
 
 static inline void h_QUANT_R2R_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
 
@@ -62,8 +62,8 @@ static inline void h_QUANT_R2R_0_f32(int& size, byte*& data, const int paramc, c
 
   const float adj_eb = (maxf - minf) * errorbound;
   data_f[len] = adj_eb;
-  if (adj_eb < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: error_bound must be at least %e, R2R error bound was calculated to be %e\n", std::numeric_limits<float>::min(), adj_eb); exit(-1);}  // minimum positive normalized value
-  if (threshold <= adj_eb) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be %e\n", adj_eb); exit(-1);}
+  if (adj_eb < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + ", R2R error bound was calculated to be " + std::to_string( adj_eb) + "\n");}  // minimum positive normalized value
+  if (threshold <= adj_eb) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be " + std::to_string(adj_eb) + "\n");}
 
   const int mantissabits = 23;
   const int maxbin = 1 << (mantissabits - 1);  // leave 1 bit for sign
@@ -97,14 +97,14 @@ static inline void h_QUANT_R2R_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_R2R_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float) - 1;
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f32(error_bound [, threshold])\n");}
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data_f;
   const float errorbound = data_f[len];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_0_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_0_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   const int mantissabits = 23;
   const float eb2 = 2 * errorbound;

--- a/preprocessors/h_QUANT_R2R_0_f64.h
+++ b/preprocessors/h_QUANT_R2R_0_f64.h
@@ -39,9 +39,9 @@ Sponsor: This code is based upon work supported by the U.S. Department of Energy
 
 static inline void h_QUANT_R2R_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
 
@@ -62,8 +62,8 @@ static inline void h_QUANT_R2R_0_f64(int& size, byte*& data, const int paramc, c
 
   const double adj_eb = (maxf - minf) * errorbound;
   data_f[len] = adj_eb;
-  if (adj_eb < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: error_bound must be at least %e, R2R error bound was calculated to be %e\n", std::numeric_limits<float>::min(), adj_eb); exit(-1);}  // minimum positive normalized value
-  if (threshold <= adj_eb) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be %e\n", adj_eb); exit(-1);}
+  if (adj_eb < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + ", R2R error bound was calculated to be " + std::to_string( adj_eb) + "\n");}  // minimum positive normalized value
+  if (threshold <= adj_eb) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be " + std::to_string(adj_eb) + "\n");}
 
   const int mantissabits = 52;
   const long long maxbin = 1LL << (mantissabits - 1);  // leave 1 bit for sign
@@ -97,14 +97,14 @@ static inline void h_QUANT_R2R_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_R2R_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(double) - 1;
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_0_f64(error_bound [, threshold])\n");}
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data_f;
   const double errorbound = data_f[len];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_0_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_0_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   const int mantissabits = 52;
   const double eb2 = 2 * errorbound;

--- a/preprocessors/h_QUANT_R2R_R_f32.h
+++ b/preprocessors/h_QUANT_R2R_R_f32.h
@@ -48,9 +48,9 @@ static unsigned int h_QUANT_R2R_R_f32_hash(unsigned int val)
 
 static inline void h_QUANT_R2R_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
 
@@ -71,8 +71,8 @@ static inline void h_QUANT_R2R_R_f32(int& size, byte*& data, const int paramc, c
 
   const float adj_eb = (maxf - minf) * errorbound;
   data_f[len] = adj_eb;
-  if (adj_eb < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: error_bound must be at least %e, R2R error bound was calculated to be %e\n", std::numeric_limits<float>::min(), adj_eb); exit(-1);}  // minimum positive normalized value
-  if (threshold <= adj_eb) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be %e\n", adj_eb); exit(-1);}
+  if (adj_eb < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + ", R2R error bound was calculated to be " + std::to_string( adj_eb) + "\n");}  // minimum positive normalized value
+  if (threshold <= adj_eb) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be " + std::to_string(adj_eb) + "\n");}
 
   const int mantissabits = 23;
   const int maxbin = 1 << (mantissabits - 1);  // leave 1 bit for sign
@@ -108,14 +108,14 @@ static inline void h_QUANT_R2R_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_R2R_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float) - 1;
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f32(error_bound [, threshold])\n");}
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data_f;
   const float errorbound = data_f[len];
-  if (errorbound < std::numeric_limits<float>::min()) {fprintf(stderr, "QUANT_R2R_R_f32: ERROR: error_bound must be at least %e\n", std::numeric_limits<float>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<float>::min()) {throw std::runtime_error("QUANT_R2R_R_f32: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<float>::min()) + "\n");}  // minimum positive normalized value
 
   const int mantissabits = 23;
   const int mask = (1 << mantissabits) - 1;

--- a/preprocessors/h_QUANT_R2R_R_f64.h
+++ b/preprocessors/h_QUANT_R2R_R_f64.h
@@ -48,9 +48,9 @@ static unsigned int h_QUANT_R2R_R_f64_hash(unsigned int val)
 
 static inline void h_QUANT_R2R_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
 
@@ -71,8 +71,8 @@ static inline void h_QUANT_R2R_R_f64(int& size, byte*& data, const int paramc, c
 
   const double adj_eb = (maxf - minf) * errorbound;
   data_f[len] = adj_eb;
-  if (adj_eb < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: error_bound must be at least %e, R2R error bound was calculated to be %e\n", std::numeric_limits<double>::min(), adj_eb); exit(-1);}  // minimum positive normalized value
-  if (threshold <= adj_eb) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be %e\n", adj_eb); exit(-1);}
+  if (adj_eb < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + ", R2R error bound was calculated to be " + std::to_string( adj_eb) + "\n");}  // minimum positive normalized value
+  if (threshold <= adj_eb) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: threshold must be larger than error_bound, R2R error bound was calculated to be " + std::to_string(adj_eb) + "\n");}
 
   const int mantissabits = 52;
   const long long maxbin = 1LL << (mantissabits - 1);  // leave 1 bit for sign
@@ -110,14 +110,14 @@ static inline void h_QUANT_R2R_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_R2R_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double) - 1;
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_R2R_R_f64(error_bound [, threshold])\n");}
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data_f;
   const double errorbound = data_f[len];
-  if (errorbound < std::numeric_limits<double>::min()) {fprintf(stderr, "QUANT_R2R_R_f64: ERROR: error_bound must be at least %e\n", std::numeric_limits<double>::min()); exit(-1);}  // minimum positive normalized value
+  if (errorbound < std::numeric_limits<double>::min()) {throw std::runtime_error("QUANT_R2R_R_f64: ERROR: error_bound must be at least " + std::to_string(std::numeric_limits<double>::min()) + "\n");}  // minimum positive normalized value
 
   const int mantissabits = 52;
   const long long mask = (1LL << mantissabits) - 1;

--- a/preprocessors/h_QUANT_REL_0_f32.h
+++ b/preprocessors/h_QUANT_REL_0_f32.h
@@ -66,13 +66,13 @@ static inline float h_QUANT_REL_0_f32_pow2approxf(const float log_f)
 
 static inline void h_QUANT_REL_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_0_f32 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_0_f32 ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_0_f32 ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // log and exp are too inaccurate below this error bound
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_0_f32 ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_0_f32 ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // log and exp are too inaccurate below this error bound
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_0_f32 ERROR: threshold must be larger than error_bound\n");}
 
   int* const data_i = (int*)data;
 
@@ -125,11 +125,11 @@ static inline void h_QUANT_REL_0_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_REL_0_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_0_f32 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_0_f32 ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_0_f32 ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // log and exp are too inaccurate below this error bound
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_0_f32 ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // log and exp are too inaccurate below this error bound
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;

--- a/preprocessors/h_QUANT_REL_0_f64.h
+++ b/preprocessors/h_QUANT_REL_0_f64.h
@@ -64,13 +64,13 @@ static inline double h_QUANT_REL_0_f64_pow2approx(const double log_f)
 
 static inline void h_QUANT_REL_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_0_f64 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_0_f64 ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_0_f64 ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // log and exp are too inaccurate below this error bound
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_0_f64 ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_0_f64 ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // log and exp are too inaccurate below this error bound
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_0_f64 ERROR: threshold must be larger than error_bound\n");}
 
   long long* const data_i = (long long*)data;
 
@@ -123,11 +123,11 @@ static inline void h_QUANT_REL_0_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_REL_0_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_0_f64 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_0_f64 ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_0_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_0_f64 ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // log and exp are too inaccurate below this error bound
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_0_f64 ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // log and exp are too inaccurate below this error bound
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;

--- a/preprocessors/h_QUANT_REL_R_f32.h
+++ b/preprocessors/h_QUANT_REL_R_f32.h
@@ -73,13 +73,13 @@ static inline float h_QUANT_REL_R_f32_pow2approxf(const float log_f)
 
 static inline void h_QUANT_REL_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_R_f32 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_R_f32 ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
   const float threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<float>::infinity();
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_R_f32 ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // log and exp are too inaccurate below this error bound
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_R_f32 ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_R_f32 ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // log and exp are too inaccurate below this error bound
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_R_f32 ERROR: threshold must be larger than error_bound\n");}
 
   int* const data_i = (int*)data;
 
@@ -135,11 +135,11 @@ static inline void h_QUANT_REL_R_f32(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_REL_R_f32(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(float) != 0) {fprintf(stderr, "QUANT_REL_R_f32 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(float)); exit(-1);}
+  if (size % sizeof(float) != 0) {throw std::runtime_error("QUANT_REL_R_f32 ERROR: size of input must be a multiple of " + std::to_string(sizeof(float)) + " bytes\n");}
   const int len = size / sizeof(float);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f32(error_bound [, threshold])\n");}
   const float errorbound = paramv[0];
-  if (errorbound < 1E-5f) {fprintf(stderr, "QUANT_REL_R_f32 ERROR: error_bound must be at least %e\n", 1E-5f); exit(-1);}  // log and exp are too inaccurate below this error bound
+  if (errorbound < 1E-5f) {throw std::runtime_error("QUANT_REL_R_f32 ERROR: error_bound must be at least " + std::to_string(1E-5f) + "\n");}  // log and exp are too inaccurate below this error bound
 
   float* const data_f = (float*)data;
   int* const data_i = (int*)data;

--- a/preprocessors/h_QUANT_REL_R_f64.h
+++ b/preprocessors/h_QUANT_REL_R_f64.h
@@ -73,13 +73,13 @@ static inline double h_QUANT_REL_R_f64_pow2approx(const double log_f)
 
 static inline void h_QUANT_REL_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_R_f64 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_R_f64 ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
   const double threshold = (paramc == 2) ? paramv[1] : std::numeric_limits<double>::infinity();
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_R_f64 ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // log and exp are too inaccurate below this error bound
-  if (threshold <= errorbound) {fprintf(stderr, "QUANT_REL_R_f64 ERROR: threshold must be larger than error_bound\n"); exit(-1);}
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_R_f64 ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // log and exp are too inaccurate below this error bound
+  if (threshold <= errorbound) {throw std::runtime_error("QUANT_REL_R_f64 ERROR: threshold must be larger than error_bound\n");}
 
   long long* const data_i = (long long*)data;
 
@@ -137,11 +137,11 @@ static inline void h_QUANT_REL_R_f64(int& size, byte*& data, const int paramc, c
 
 static inline void h_iQUANT_REL_R_f64(int& size, byte*& data, const int paramc, const double paramv [])
 {
-  if (size % sizeof(double) != 0) {fprintf(stderr, "QUANT_REL_R_f64 ERROR: size of input must be a multiple of %ld bytes\n", sizeof(double)); exit(-1);}
+  if (size % sizeof(double) != 0) {throw std::runtime_error("QUANT_REL_R_f64 ERROR: size of input must be a multiple of " + std::to_string(sizeof(double)) + " bytes\n");}
   const int len = size / sizeof(double);
-  if ((paramc != 1) && (paramc != 2)) {fprintf(stderr, "USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n"); exit(-1);}
+  if ((paramc != 1) && (paramc != 2)) {throw std::runtime_error("USAGE: QUANT_REL_R_f64(error_bound [, threshold])\n");}
   const double errorbound = paramv[0];
-  if (errorbound < 1E-7) {fprintf(stderr, "QUANT_REL_R_f64 ERROR: error_bound must be at least %e\n", 1E-7); exit(-1);}  // log and exp are too inaccurate below this error bound
+  if (errorbound < 1E-7) {throw std::runtime_error("QUANT_REL_R_f64 ERROR: error_bound must be at least " + std::to_string(1E-7) + "\n");}  // log and exp are too inaccurate below this error bound
 
   double* const data_f = (double*)data;
   long long* const data_i = (long long*)data;


### PR DESCRIPTION
@burtscher this commit refactors the preprocessors to use not call `exit(1)`, add's `lc-gpu` to the spack package, and extracts a common header.  It is not ready to release yet because `framework-common.h` does not yet have the implementing functions.  I wasn't sure where you wanted to put their bodies and run the code generator over them.